### PR TITLE
Correct bearing value

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -111,7 +111,7 @@ function App(): React.Node {
               const green = 255 - red - blue;
               return [red, green, blue, 255];
             },
-            getAngle: (d: Point) => d.bearing,
+            getAngle: (d: Point) => 180 - d.bearing,
             billboard: false,
             onHover: (info: HoverInfo) => setHoverInfo(info),
           });


### PR DESCRIPTION
The `getAngle()` callback for the IconLayer is out-of-phase from the compass bearing by 180 degrees so we need to correct for that.  