### PR TITLE
Add AppBar with app title

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -10,7 +10,7 @@
  */
 
 import * as React from 'react';
-import MapScreen from './screens/mapscreen';
+import MapScreen from './screens/MapScreen';
 import { createMuiTheme } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/core/styles';
 

--- a/app/src/screens/mapscreen.js
+++ b/app/src/screens/mapscreen.js
@@ -10,7 +10,7 @@
  */
 
 import * as React from 'react';
-import {useRef, useState} from 'react';
+import { useRef, useState } from 'react';
 
 import AppBar from '@material-ui/core/AppBar';
 import Button from '@material-ui/core/Button';
@@ -18,18 +18,18 @@ import ButtonGroup from '@material-ui/core/ButtonGroup';
 import DeckGL from 'deck.gl';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
-import {COORDINATE_SYSTEM} from '@deck.gl/core';
-import {IconLayer, PointCloudLayer} from '@deck.gl/layers';
-import ReactMapGL, {NavigationControl} from 'react-map-gl';
+import { COORDINATE_SYSTEM } from '@deck.gl/core';
+import { IconLayer, PointCloudLayer } from '@deck.gl/layers';
+import ReactMapGL, { NavigationControl } from 'react-map-gl';
 import { makeStyles } from '@material-ui/core/styles';
 
-import type {PickInfo} from "@deck.gl/core/lib/deck";
+import type { PickInfo } from "@deck.gl/core/lib/deck";
 
 const MAPBOX_TOKEN = process.env.MAPBOX_TOKEN;
 
 const MIN_ELEVATION = 10;
 const ICON_MAPPING = {
-  marker: {x: 0, y: 0, width: 128, height: 128, mask: true},
+  marker: { x: 0, y: 0, width: 128, height: 128, mask: true },
 };
 
 type ViewState = {
@@ -232,7 +232,7 @@ function MapScreen(): React.Node {
         layers={layers}
         getTooltip={(p: Point) => p.message}>
         <ReactMapGL mapboxApiAccessToken={MAPBOX_TOKEN} mapStyle={mapStyle}>
-          <div style={{position: 'absolute', right: 0}}>
+          <div style={{ position: 'absolute', right: 0 }}>
             <NavigationControl showCompass={true} showZoom={false} />
           </div>
         </ReactMapGL>
@@ -269,7 +269,7 @@ function MapScreen(): React.Node {
         <input
           type="file"
           ref={fileInput}
-          style={{display: 'none'}}
+          style={{ display: 'none' }}
           onChange={handleFile}
           multiple="multiple"
         />
@@ -295,12 +295,12 @@ function MapScreen(): React.Node {
 }
 
 const useStyles = makeStyles((theme) => ({
-    root: {
-      flexGrow: 1,
-    },
-    title: {
-      flexGrow: 1,
-    },
-  }));
+  root: {
+    flexGrow: 1,
+  },
+  title: {
+    flexGrow: 1,
+  },
+}));
 
 export default MapScreen;

--- a/app/src/screens/mapscreen.js
+++ b/app/src/screens/mapscreen.js
@@ -12,12 +12,16 @@
 import * as React from 'react';
 import {useRef, useState} from 'react';
 
+import AppBar from '@material-ui/core/AppBar';
 import Button from '@material-ui/core/Button';
 import ButtonGroup from '@material-ui/core/ButtonGroup';
 import DeckGL from 'deck.gl';
+import Toolbar from '@material-ui/core/Toolbar';
+import Typography from '@material-ui/core/Typography';
 import {COORDINATE_SYSTEM} from '@deck.gl/core';
 import {IconLayer, PointCloudLayer} from '@deck.gl/layers';
 import ReactMapGL, {NavigationControl} from 'react-map-gl';
+import { makeStyles } from '@material-ui/core/styles';
 
 import type {PickInfo} from "@deck.gl/core/lib/deck";
 
@@ -218,6 +222,8 @@ function MapScreen(): React.Node {
     setSatelliteView(true);
   }
 
+  const classes = useStyles();
+
   return (
     <div>
       <DeckGL
@@ -230,6 +236,15 @@ function MapScreen(): React.Node {
             <NavigationControl showCompass={true} showZoom={false} />
           </div>
         </ReactMapGL>
+        <div className={classes.root}>
+          <AppBar position="static">
+            <Toolbar>
+              <Typography variant="h6" className={classes.title}>
+                3D Coverage Maps
+              </Typography>
+            </Toolbar>
+          </AppBar>
+        </div>
         <div
           style={{
             padding: 10,
@@ -278,5 +293,14 @@ function MapScreen(): React.Node {
     </div>
   );
 }
+
+const useStyles = makeStyles((theme) => ({
+    root: {
+      flexGrow: 1,
+    },
+    title: {
+      flexGrow: 1,
+    },
+  }));
 
 export default MapScreen;


### PR DESCRIPTION
Added an AppBar to display the app title.

Also renamed mapscreen to MapScreen to set a convention of matching class names with the file name.
![Screen Shot 2020-11-30 at 10 40 00 PM](https://user-images.githubusercontent.com/6796073/100705989-05f74b80-335d-11eb-8e8d-468b20bbfbd1.png)
