### PR TITLE
Cache maps dialog

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>RF 3d Coverage Maps</title>
+    <title>3D Coverage Maps</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -10,7 +10,7 @@
  */
 
 import * as React from 'react';
-import MapScreen from './screens/mapscreen';
+import MapScreen from './screens/MapScreen';
 import { createMuiTheme } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/core/styles';
 

--- a/app/src/components/CacheMapsDialog.js
+++ b/app/src/components/CacheMapsDialog.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+import * as React from 'react';
+import { useState } from 'react';
+
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import PropTypes from 'prop-types';
+import TextField from '@material-ui/core/TextField';
+
+function CacheMapsDialog(props) {
+    const [latitude, setLatitude] = useState<?number>(null);
+    const [longitude, setLongitude] = useState<?number>(null);
+    const [showError, setShowError] = useState<boolean>(false);
+    const { onClose, open } = props;
+
+    const handleCancel = () => {
+        onClose();
+    }
+
+    const handleDownload = () => {
+        if (longitude && latitude && latitude >= -90 && latitude <= 90 && longitude >= -180 && longitude <= 180) {
+            onClose(latitude, longitude);
+        } else {
+            setShowError(true);
+        }
+    }
+
+    return (
+        <Dialog onClose={handleCancel} aria-labelledby="simple-dialog-title" open={open}>
+            <DialogTitle id="simple-dialog-title">Download Offline Maps</DialogTitle>
+            <DialogContent>
+                <DialogContentText>
+                    Enter the latitude and longitude of the area that should be downloaded.
+                </DialogContentText>
+                <TextField
+                    autoFocus
+                    margin="dense"
+                    id="latitude"
+                    label="Latitude"
+                    type="number"
+                    onChange={(event) => { 
+                        setShowError(false);
+                        setLatitude(parseFloat(event.target.value))
+                    }}
+                />
+                <TextField
+                    margin="dense"
+                    id="longitude"
+                    label="Longitude"
+                    type="number"
+                    onChange={(event) => { 
+                        setShowError(false);
+                        setLongitude(parseFloat(event.target.value))
+                    }}
+                />
+                <DialogContentText>
+                    {showError ? "Latitude must be between -90 and 90, and Longitude must be between -180 and 180." : null}
+                </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={handleCancel} color="primary">
+                    Cancel
+                </Button>
+                <Button onClick={handleDownload} color="primary">
+                    Download
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}
+
+CacheMapsDialog.propTypes = {
+    onClose: PropTypes.func.isRequired,
+    open: PropTypes.bool.isRequired,
+};
+
+export default CacheMapsDialog;

--- a/app/src/screens/mapscreen.js
+++ b/app/src/screens/mapscreen.js
@@ -10,7 +10,7 @@
  */
 
 import * as React from 'react';
-import {useRef, useState} from 'react';
+import { useRef, useState } from 'react';
 
 import AppBar from '@material-ui/core/AppBar';
 import Button from '@material-ui/core/Button';
@@ -18,18 +18,18 @@ import ButtonGroup from '@material-ui/core/ButtonGroup';
 import DeckGL from 'deck.gl';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
-import {COORDINATE_SYSTEM} from '@deck.gl/core';
-import {IconLayer, PointCloudLayer} from '@deck.gl/layers';
-import ReactMapGL, {NavigationControl} from 'react-map-gl';
+import { COORDINATE_SYSTEM } from '@deck.gl/core';
+import { IconLayer, PointCloudLayer } from '@deck.gl/layers';
+import ReactMapGL, { NavigationControl } from 'react-map-gl';
 import { makeStyles } from '@material-ui/core/styles';
 
-import type {PickInfo} from "@deck.gl/core/lib/deck";
+import type { PickInfo } from "@deck.gl/core/lib/deck";
 
 const MAPBOX_TOKEN = process.env.MAPBOX_TOKEN;
 
 const MIN_ELEVATION = 10;
 const ICON_MAPPING = {
-  marker: {x: 0, y: 0, width: 128, height: 128, mask: true},
+  marker: { x: 0, y: 0, width: 128, height: 128, mask: true },
 };
 
 type ViewState = {
@@ -232,7 +232,7 @@ function MapScreen(): React.Node {
         layers={layers}
         getTooltip={(p: Point) => p.message}>
         <ReactMapGL mapboxApiAccessToken={MAPBOX_TOKEN} mapStyle={mapStyle}>
-          <div style={{position: 'absolute', right: 0}}>
+          <div style={{ position: 'absolute', right: 0 }}>
             <NavigationControl showCompass={true} showZoom={false} />
           </div>
         </ReactMapGL>
@@ -269,7 +269,7 @@ function MapScreen(): React.Node {
         <input
           type="file"
           ref={fileInput}
-          style={{display: 'none'}}
+          style={{ display: 'none' }}
           onChange={handleFile}
           multiple="multiple"
         />
@@ -295,12 +295,12 @@ function MapScreen(): React.Node {
 }
 
 const useStyles = makeStyles((theme) => ({
-    root: {
-      flexGrow: 1,
-    },
-    title: {
-      flexGrow: 1,
-    },
-  }));
+  root: {
+    flexGrow: 1,
+  },
+  title: {
+    flexGrow: 1,
+  },
+}));
 
 export default MapScreen;

--- a/app/src/screens/mapscreen.js
+++ b/app/src/screens/mapscreen.js
@@ -15,6 +15,7 @@ import { useRef, useState } from 'react';
 import AppBar from '@material-ui/core/AppBar';
 import Button from '@material-ui/core/Button';
 import ButtonGroup from '@material-ui/core/ButtonGroup';
+import CacheMapsDialog from '../components/CacheMapsDialog';
 import DeckGL from 'deck.gl';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
@@ -60,6 +61,7 @@ function MapScreen(): React.Node {
     'mapbox://styles/mapbox/satellite-v9',
   );
   const [satelliteView, setSatelliteView] = useState<boolean>(true);
+  const [cacheMapDialogOpen, setCacheMapDialogOpen] = useState<boolean>(false);
 
   // Initialize view to MPK Campus
   const [view, setView] = useState<ViewState>({
@@ -222,6 +224,35 @@ function MapScreen(): React.Node {
     setSatelliteView(true);
   }
 
+  function openMapCacheDialog() {
+    setCacheMapDialogOpen(true);
+  }
+
+  function closeMapCacheDialog(latitude: ?number, longitude: ?number) {
+    if (longitude && latitude) {
+      setView({
+        latitude: latitude,
+        longitude: longitude,
+        zoom: 17,
+        bearing: 0,
+        pitch: 45,
+    });
+    }
+    setCacheMapDialogOpen(false);
+  }
+
+
+/*
+  const [view, setView] = useState<ViewState>({
+    latitude: 37.483175,
+    longitude: -122.150084,
+    zoom: 17,
+    bearing: 0,
+    pitch: 45,
+  });
+*/
+
+
   const classes = useStyles();
 
   return (
@@ -265,6 +296,9 @@ function MapScreen(): React.Node {
           Ignoring all points under {MIN_ELEVATION} meters
           <p />
           Option+click to rotate map
+          <p />
+          <Button variant="outlined" color="secondary" onClick={openMapCacheDialog}>Download offline maps</Button>
+          <CacheMapsDialog open={cacheMapDialogOpen} onClose={closeMapCacheDialog} />
         </div>
         <input
           type="file"

--- a/app/src/screens/mapscreen.js
+++ b/app/src/screens/mapscreen.js
@@ -12,12 +12,16 @@
 import * as React from 'react';
 import {useRef, useState} from 'react';
 
+import AppBar from '@material-ui/core/AppBar';
 import Button from '@material-ui/core/Button';
 import ButtonGroup from '@material-ui/core/ButtonGroup';
 import DeckGL from 'deck.gl';
+import Toolbar from '@material-ui/core/Toolbar';
+import Typography from '@material-ui/core/Typography';
 import {COORDINATE_SYSTEM} from '@deck.gl/core';
 import {IconLayer, PointCloudLayer} from '@deck.gl/layers';
 import ReactMapGL, {NavigationControl} from 'react-map-gl';
+import { makeStyles } from '@material-ui/core/styles';
 
 import type {PickInfo} from "@deck.gl/core/lib/deck";
 
@@ -218,6 +222,8 @@ function MapScreen(): React.Node {
     setSatelliteView(true);
   }
 
+  const classes = useStyles();
+
   return (
     <div>
       <DeckGL
@@ -230,6 +236,15 @@ function MapScreen(): React.Node {
             <NavigationControl showCompass={true} showZoom={false} />
           </div>
         </ReactMapGL>
+        <div className={classes.root}>
+          <AppBar position="static">
+            <Toolbar>
+              <Typography variant="h6" className={classes.title}>
+                3D Coverage Maps
+              </Typography>
+            </Toolbar>
+          </AppBar>
+        </div>
         <div
           style={{
             padding: 10,
@@ -278,5 +293,14 @@ function MapScreen(): React.Node {
     </div>
   );
 }
+
+const useStyles = makeStyles((theme) => ({
+    root: {
+      flexGrow: 1,
+    },
+    title: {
+      flexGrow: 1,
+    },
+  }));
 
 export default MapScreen;


### PR DESCRIPTION
Button that opens a dialog so the user can enter a lat/long to change the map viewscape.  This forces mapbox to download the desired tiles which are stored in the browser cache.
[Screen Recording 2020-11-30 at 11.35.51 PM.mov.zip](https://github.com/facebookexperimental/rf-coverage-maps/files/5620932/Screen.Recording.2020-11-30.at.11.35.51.PM.mov.zip)

