### PR TITLE
Add material-ui/styles flow types

### DIFF
--- a/app/flow-typed/npm/@material-ui/core_v1.x.x.js
+++ b/app/flow-typed/npm/@material-ui/core_v1.x.x.js
@@ -2536,6 +2536,7 @@ declare module "@material-ui/core/AppBar/AppBar" {
   }
 
   declare module "@material-ui/core/styles" {
+    import type {ComponentType, Node} from 'react';
     import type { Theme as MuiTheme } from "@material-ui/core/styles/createMuiTheme";
     import type { WithStyles as MuiWithStyles } from "@material-ui/core/styles/withStyles";
     import type { WithTheme as MuiWithTheme } from "@material-ui/core/styles/withTheme";
@@ -2544,15 +2545,34 @@ declare module "@material-ui/core/AppBar/AppBar" {
     declare export type WithStyles<T> = MuiWithStyles<T>;
     declare export type WithTheme = MuiWithTheme;
 
+    declare class ServerStyleSheets {
+      collect: Node => Node;
+    }
+
+    declare type Style<Props, Classes> = $Shape<{
+      [Classes]: {...} | (Props => {...}),
+    }>;
+
+    declare type StyleHookFn<_Props, Stl> = (
+      props?: _Props,
+    ) => $ObjMap<Stl, () => string>;
+
     declare module.exports: {
       MuiThemeProvider: $Exports<"@material-ui/core/styles/MuiThemeProvider">,
       withStyles: $Exports<"@material-ui/core/styles/withStyles">,
       withTheme: $Exports<"@material-ui/core/styles/withTheme">,
       createGenerateClassName: $Exports<
-        "@material-ui/core/styles/createGenerateClassName"
+      "@material-ui/core/styles/createGenerateClassName"
       >,
       createMuiTheme: $Exports<"@material-ui/core/styles/createMuiTheme">,
       jssPreset: $Exports<"@material-ui/core/styles/jssPreset">,
+      makeStyles: <Props, Stl: Style<Props, string>>(
+        Theme => Stl,
+      ) => StyleHookFn<Props, Stl>,
+      StylesProvider: ComponentType<{generateClassName?: () => string}>,
+      ServerStyleSheets: Class<ServerStyleSheets>,
+      createGenerateClassName: () => () => string,
+      useTheme: () => Theme,
     };
   }
 


### PR DESCRIPTION
Previously (fbc), we used the standalone, but it's actually re-exported:
"@material-ui/styles is re-exported as @material-ui/core/styles - you only need to install it if you wish to use it independently from Material-UI."
