### PR TITLE
Serverless support (SVG Arrow)

### DIFF
--- a/app/src/components/ArrowElement.js
+++ b/app/src/components/ArrowElement.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+function getArrow(): HTMLImageElement {
+  // The xmlns MUST be present.
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M 20,12.6 18.59,11.19 13,16.77 V 0 H 11 V 16.77 L 5.42,11.18 4,12.6 l 8,8 z"/></svg>`;
+  const blob = new Blob([svg], {type: 'image/svg+xml'});
+  const url = URL.createObjectURL(blob);
+  const Arrow = document.createElement('img');
+  Arrow.src = url;
+  Arrow.addEventListener('load', () => URL.revokeObjectURL(url), {once: true});
+  return Arrow;
+}
+
+export default getArrow;

--- a/app/src/screens/MapScreen.js
+++ b/app/src/screens/MapScreen.js
@@ -37,10 +37,12 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
 import Checkbox from '@material-ui/core/Checkbox';
+import getArrow from '../components/ArrowElement';
 
 import type {ViewStateProps, PickInfo} from '@deck.gl/core/lib/deck';
 
 const MAPBOX_TOKEN = process.env.MAPBOX_TOKEN;
+const Arrow = getArrow();
 
 const MIN_ELEVATION = 10;
 const ICON_MAPPING = {
@@ -197,7 +199,8 @@ function MapScreen(): React.Node {
           visible: customLayers[name].visible,
           pickable: true,
           // iconAtlas and iconMapping are required
-          iconAtlas: 'arrow.png',
+          // $FlowFixMe Images actually work fine.
+          iconAtlas: Arrow,
           iconMapping: ICON_MAPPING,
           // getIcon: return a string
           getIcon: (_d: Point) => 'marker',


### PR DESCRIPTION
The only thing stopping us from serving directly from the harddisk (using file://) was the arrow.png.
This creates an svg arrow using an HTML element, and passes that to the map.

The arrow is the material UI arrow pointing down that I extended the tail for, and ensured the tip wasn't clipped when rendering.

We could very likely do this same trick using the png, I just wasn't sure how to load the asset and went the SVG string route.

Now, once you load a page (either through dev mode using `yarn start`, or development using `yarn build` and ` serve -s build`), you can then save the whole page through chrome and serve that folder.

e.g.
![Screen Shot 2020-12-02 at 3 05 26 AM](https://user-images.githubusercontent.com/7523484/100845513-5baa2180-344b-11eb-83cc-300c11c84144.png)
![Screen Shot 2020-12-02 at 3 06 12 AM](https://user-images.githubusercontent.com/7523484/100845530-5fd63f00-344b-11eb-92fc-9f1e509a2e3a.png)
