### PR TITLE
Handle Mapbox token with dialog and cookie

### DIFF
--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -22,7 +22,7 @@ function createWindow() {
     show: false,
   });
   const startURL = isDev
-    ? 'http://localhost:3000/?access_token=pk.eyJ1IjoiZmFubnlraGlldSIsImEiOiJja2k0eWRqcWcwNzI4MnBxbzM5bGllYjZ2In0.VjNz3ZjqXvByKLYAqqIgTg'
+    ? 'http://localhost:3000/'
     : `file://${path.join(__dirname, '../public/index.html')}`;
 
   mainWindow.loadURL(startURL);

--- a/app/package.json
+++ b/app/package.json
@@ -1,15 +1,14 @@
 {
   "name": "rf-coverage-maps",
-  "homepage": "./",
+  "homepage": ".",
   "main": "./electron/main.js",
   "version": "0.1.0",
   "private": true,
-  "homepage": ".",
   "scripts": {
     "start": "BROWSER=none react-scripts start",
     "build": "yarn run build:build build:zip",
     "build:build": "react-scripts build",
-    "build:zip": "cd build && zip -r -X ../build.zip .",   
+    "build:zip": "cd build && zip -r -X ../build.zip .",
     "test": "react-scripts test",
     "dev": "concurrently \"yarn start\" \"wait-on http://localhost:3000 && electron .\"",
     "ebuild": "yarn build && node_modules/.bin/build"
@@ -35,6 +34,7 @@
     "electron-is-dev": "^1.2.0",
     "mapbox-gl": "^1.12.0",
     "react": "^16.13.1",
+    "react-cookie": "^4.0.3",
     "react-dom": "^16.13.1",
     "react-map-gl": "^4.1.2",
     "react-scripts": "^3.4.3",

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -13,6 +13,7 @@ import * as React from 'react';
 import MapScreen from './screens/MapScreen';
 import {createMuiTheme} from '@material-ui/core/styles';
 import {MuiThemeProvider} from '@material-ui/core/styles';
+import {CookiesProvider} from 'react-cookie';
 
 function App(): React.Node {
   const theme = createMuiTheme({
@@ -31,7 +32,9 @@ function App(): React.Node {
 
   return (
     <MuiThemeProvider theme={theme}>
-      <MapScreen />
+      <CookiesProvider>
+        <MapScreen />
+      </CookiesProvider>
     </MuiThemeProvider>
   );
 }

--- a/app/src/components/MapboxTokenDialog.js
+++ b/app/src/components/MapboxTokenDialog.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+import * as React from 'react';
+import {useState} from 'react';
+
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import Link from '@material-ui/core/Link';
+import TextField from '@material-ui/core/TextField';
+
+type Props = {
+  onClose: (?string) => void,
+};
+
+function MapboxTokenDialog(props: Props): React.Node {
+  const [token, setToken] = useState<?string>();
+  const {onClose} = props;
+
+  const handleCancel = () => {
+    onClose();
+  };
+
+  const handleConfirm = () => {
+    onClose(token);
+  };
+
+  return (
+    <Dialog
+      onClose={handleCancel}
+      aria-labelledby="simple-dialog-title"
+      open={true}>
+      <DialogTitle id="simple-dialog-title">Mapbox Token</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          Enter your Mapbox token to be able to view maps.
+        </DialogContentText>
+        <DialogContentText variant="body2">
+          Mapbox tokens can be found at{' '}
+          <Link href="https://account.mapbox.com/access-tokens/">
+            https://account.mapbox.com/access-tokens/
+          </Link>
+          .
+        </DialogContentText>
+        <TextField
+          required
+          fullWidth
+          autoFocus
+          id="token"
+          label="Token"
+          type="string"
+          onChange={event => {
+            setToken(event.target.value);
+          }}          
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCancel} color="primary">
+          Cancel
+        </Button>
+        <Button onClick={handleConfirm} color="primary">
+          Confirm
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default MapboxTokenDialog;

--- a/app/src/components/MapboxTokenDialog.js
+++ b/app/src/components/MapboxTokenDialog.js
@@ -60,7 +60,7 @@ function MapboxTokenDialog(props: Props): React.Node {
           autoFocus
           id="token"
           label="Token"
-          type="string"
+          type="password"
           onChange={event => {
             setToken(event.target.value);
           }}          

--- a/app/src/screens/MapScreen.js
+++ b/app/src/screens/MapScreen.js
@@ -22,6 +22,7 @@ import Divider from '@material-ui/core/Divider';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 import CacheMapsDialog from '../components/CacheMapsDialog';
+import MapboxTokenDialog from '../components/MapboxTokenDialog';
 import DeckGL from 'deck.gl';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
@@ -31,13 +32,13 @@ import {makeStyles} from '@material-ui/core/styles';
 import RssiHeightGraph from '../components/RssiHeightGraph';
 import SignalStrengthLegend from '../components/SignalStrengthLegend';
 import {getRGBTurbo} from '../utils/ColorUtils';
+import {useCookies} from 'react-cookie';
 
 import LayerList from '../components/LayerList';
 import getArrow from '../components/ArrowElement';
 
 import type {ViewStateProps, PickInfo} from '@deck.gl/core/lib/deck';
 
-const MAPBOX_TOKEN = process.env.MAPBOX_TOKEN;
 const Arrow = getArrow();
 
 const ICON_MAPPING = {
@@ -89,6 +90,7 @@ function MapScreen(): React.Node {
   const [filterMaxRssi, setFilterMaxRssi] = useState('');
   const [filterMinHeight, setFilterMinHeight] = useState('10');
   const [filterMaxHeight, setFilterMaxHeight] = useState('');
+  const [cookies, setCookie] = useCookies(['token']);
 
   // Initialize view to MPK Campus
   const [view, setView] = useState<ViewStateProps>({
@@ -339,8 +341,13 @@ function MapScreen(): React.Node {
     setCacheMapDialogOpen(false);
   }
 
-  const classes = useStyles();
+  function closeMapboxTokenDialog(token: ?string) {
+    if (token) {
+      setCookie('token', token, {path: '/'});
+    }
+  }
 
+  const classes = useStyles();
   return (
     <div>
       <DeckGL
@@ -373,16 +380,20 @@ function MapScreen(): React.Node {
             </Toolbar>
           </AppBar>
         </div>
-        <ReactMapGL mapboxApiAccessToken={MAPBOX_TOKEN} mapStyle={mapStyle}>
-          <div style={{position: 'absolute', right: 0}}>
-            <NavigationControl showCompass={true} showZoom={false} />
-          </div>
-          <div style={{position: 'absolute', right: 35}}>
-            <Paper className={classes.rightSideBar}>
-              <SignalStrengthLegend />
-            </Paper>
-          </div>
-        </ReactMapGL>
+        {cookies.token ? (
+          <ReactMapGL mapboxApiAccessToken={cookies.token} mapStyle={mapStyle}>
+            <div style={{position: 'absolute', right: 0}}>
+              <NavigationControl showCompass={true} showZoom={false} />
+            </div>
+            <div style={{position: 'absolute', right: 35}}>
+              <Paper className={classes.rightSideBar}>
+                <SignalStrengthLegend />
+              </Paper>
+            </div>
+          </ReactMapGL>
+        ) : (
+          <MapboxTokenDialog onClose={closeMapboxTokenDialog} />
+        )}
         <Paper className={classes.sideBar}>
           <Grid container spacing={3} alignItems="stretch" direction="column">
             <Grid item xs={3}>

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2136,6 +2136,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/cookie@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
+  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
+
 "@types/debug@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
@@ -2160,6 +2165,14 @@
   dependencies:
     "@types/minimatch" "*"
     "@types/node" "*"
+
+"@types/hoist-non-react-statics@^3.0.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.3"
@@ -4068,6 +4081,11 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
+cookie@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -6586,7 +6604,7 @@ hoek@4.2.1:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
   integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
 
-hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -10589,6 +10607,15 @@ react-app-polyfill@^1.0.6:
     regenerator-runtime "^0.13.3"
     whatwg-fetch "^3.0.0"
 
+react-cookie@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/react-cookie/-/react-cookie-4.0.3.tgz#ba8e5ea0047c916516e1181a3ad394c9b7580b56"
+  integrity sha512-cmi6IpdVgTSvjqssqIEvo779Gfqc4uPGHRrKMEdHcqkmGtPmxolGfsyKj95bhdLEKqMdbX8MLBCwezlnhkHK0g==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.0.1"
+    hoist-non-react-statics "^3.0.0"
+    universal-cookie "^4.0.0"
+
 react-dev-utils@^10.2.1:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-10.2.1.tgz#f6de325ae25fa4d546d09df4bb1befdc6dd19c19"
@@ -12514,6 +12541,14 @@ unique-string@^2.0.0:
   integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
   dependencies:
     crypto-random-string "^2.0.0"
+
+universal-cookie@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.4.tgz#06e8b3625bf9af049569ef97109b4bb226ad798d"
+  integrity sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==
+  dependencies:
+    "@types/cookie" "^0.3.3"
+    cookie "^0.4.0"
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
Instead of relying on an access_token param in the URL, this PR adds a dialog to allow the user to enter a mapbox token.  The token is stored as a cookie so refreshing the page won't trigger the dialog again.

I also deleted the MAPBOX_TOKEN const since it's not necessary.
[Screen Recording 2020-12-03 at 4.23.26 PM.mov.zip](https://github.com/facebookexperimental/rf-coverage-maps/files/5639840/Screen.Recording.2020-12-03.at.4.23.26.PM.mov.zip)
