### PR TITLE
Fix colormap

### DIFF
--- a/app/src/components/SignalStrengthLegend.js
+++ b/app/src/components/SignalStrengthLegend.js
@@ -27,9 +27,11 @@ type Props = {
 function SignalStrengthLegend(props: Props): React.Node {
   const [min, max] = props.range;
   const range = max - min;
-  const bucketSize = range / (props.heatmap.length - 1);
+  const numBucketsRendered = props.heatmap.length;
+  // Subtract one to always have start and end of range
+  const bucketSize = range / (numBucketsRendered - 1);
 
-  const values = [...new Array(props.heatmap.length)].map(
+  const values = [...new Array(numBucketsRendered)].map(
     (_, i) => max - bucketSize * i,
   );
   return (

--- a/app/src/utils/ColorUtils.js
+++ b/app/src/utils/ColorUtils.js
@@ -52,8 +52,8 @@ export function getRGBCustom(
   const shiftedValue = value - min;
   const bucket = Math.floor(shiftedValue / bucketSize);
   // How far between the buckets is it, for interpolating between colors
-  const weight = shiftedValue - bucket * bucketSize;
-  const inverseWeight = 1 - weight;
+  const inverseWeight = (shiftedValue - bucket * bucketSize) / bucketSize;
+  const weight = 1 - inverseWeight;
 
   return [
     Math.round(


### PR DESCRIPTION
- Weight was being computed incorrectly. Firstly, it wasn't normalized by the bucket weight. Secondly, weight and inverse weight were inverted.
- Also allow specifying the number of buckets for the legend, and clarify why we're subtracting one (this helped with testing)

Colormap legend with 2x the markers:
![Screen Shot 2020-12-03 at 10 29 46 PM](https://user-images.githubusercontent.com/7523484/101118802-d7c17800-35b7-11eb-9d9d-d3c1d3f6edee.png)
Final result:
![Screen Shot 2020-12-03 at 10 30 36 PM](https://user-images.githubusercontent.com/7523484/101118803-d85a0e80-35b7-11eb-858c-39995b0bd9f5.png)
