### PR TITLE
Upgrade vulnerable dependency ini@ package

### DIFF
--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -6941,9 +6941,9 @@ inherits@2.0.3:
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 inquirer@7.0.4:
   version "7.0.4"


### PR DESCRIPTION
Deleted ini@ from yarn.lock and ran yarn to resolve the latest version.

Package name: ini
Affected versions: < 1.3.6
Fixed in version: 1.3.6
Severity: LOW

Identifier(s):
GHSA-qqgx-2p2h-9c37

Reference(s):
https://github.com/npm/ini/commit/56d2805e07ccd94e2ba0984ac9240ff02d44b6f1
https://github.com/advisories/GHSA-qqgx-2p2h-9c37
