### PR TITLE
Create a new tag on commits.

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -21,6 +21,12 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v5.1
+        with:
+          release_branches: master
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - run: npm install -g yarn
       - run: yarn install
       - run: yarn build
@@ -30,7 +36,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: app/build.zip
           asset_name: rf-coverage-maps.zip
-          tag: ${{ github.ref }}
+          release_name: Build ${{ steps.tag_version.outputs.new_tag }}
+          tag: ${{ steps.tag_version.outputs.new_tag }}
           overwrite: true
-          body: "Automatic build of main branch."
-          prerelease: true
+          body: Automatic build of main branch. \n${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
Github tags should not change (and do not change).
Thus, the release tag we used won't move.

In fact, our current most up to date release doesn't show up under the main github page which instead points to the release tag. Seeing all releases, does show the draft release however.

This PR does a few things:
- creates a new tag on each main merge
- Includes the changelog
- Doesn't mark as prerelease (so it should show up on the main github page)