### PR TITLE
Use localStorage instead of cookie to store mapbox token

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -34,7 +34,6 @@
     "electron-is-dev": "^1.2.0",
     "mapbox-gl": "^1.12.0",
     "react": "^16.13.1",
-    "react-cookie": "^4.0.3",
     "react-dom": "^16.13.1",
     "react-map-gl": "^5.2.10",
     "react-scripts": "^4.0.1",

--- a/app/src/screens/MapScreen.js
+++ b/app/src/screens/MapScreen.js
@@ -94,16 +94,17 @@ function MapScreen(): React.Node {
   const [filterMaxRssi, setFilterMaxRssi] = useState<string>('');
   const [filterMinHeight, setFilterMinHeight] = useState<string>('10');
   const [filterMaxHeight, setFilterMaxHeight] = useState<string>('');
-  const [token, setToken] = useState<?string>(() => {
-    const mapboxToken =
+  const [token, setToken] = useState<?string>(
+    () =>
       new URLSearchParams(window.location.search).get('access_token') ??
-      localStorage.getItem(TOKEN_KEY);
-    return mapboxToken;
-  });
+      localStorage.getItem(TOKEN_KEY),
+  );
 
-  const [tokenDialogOpen, setTokenDialogOpen] = useState<boolean>(() => {
-    return localStorage.getItem(TOKEN_KEY) == null;
-  });
+  const [tokenDialogOpen, setTokenDialogOpen] = useState<boolean>(
+    () =>
+      new URLSearchParams(window.location.search).get('access_token') == null &&
+      localStorage.getItem(TOKEN_KEY) == null,
+  );
 
   // Initialize view to MPK Campus
   const [view, setView] = useState<ViewStateProps>({


### PR DESCRIPTION
Cookies are not supported in Chrome for file:/// paths.  This PR switches storing the token from a cookie to localStorage.

![image](https://user-images.githubusercontent.com/6796073/104528193-6b289880-55bb-11eb-84f9-bbcf0fdff6e7.png)
