### PR TITLE
Upgrade ws from version 7.4.2 to 7.4.6

### DIFF
--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -14843,9 +14843,9 @@ ws@^6.2.1:
     async-limiter "~1.0.0"
 
 ws@^7.2.3:
-  version "7.4.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.2.tgz#782100048e54eb36fe9843363ab1c68672b261dd"
-  integrity sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Upgrade ws@7.4.2 to ws@7.4.6

Reference(s):
https://github.com/websockets/ws/security/advisories/GHSA-6fc8-4gx4-v693
https://nvd.nist.gov/vuln/detail/CVE-2021-32640
https://github.com/advisories/GHSA-6fc8-4gx4-v693